### PR TITLE
Renamed and moved the `EraserLifecycleObserver` to be `AnimatorLifecycleObserver`

### DIFF
--- a/eraser/build.gradle
+++ b/eraser/build.gradle
@@ -38,6 +38,7 @@ android {
 
 dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-common-java8:2.3.1"
     implementation "androidx.fragment:fragment-ktx:1.3.6"
     implementation "androidx.activity:activity-ktx:1.3.1"
 }

--- a/eraser/src/main/java/uk/co/jordanterry/eraser/eraser.kt
+++ b/eraser/src/main/java/uk/co/jordanterry/eraser/eraser.kt
@@ -3,10 +3,8 @@ package uk.co.jordanterry.eraser
 import android.animation.Animator
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
+import uk.co.jordanterry.eraser.observers.AnimatorLifecycleObserver
 
 /**
  * Handle the lifecycle functions of an [Animator] as per the lifecycle of an Activity.
@@ -18,12 +16,12 @@ import androidx.lifecycle.OnLifecycleEvent
  * @param animator that must be erased
  */
 fun ComponentActivity.erase(animator: Animator) {
-    lifecycle.addObserver(EraserLifecycleObserver(animator))
+    lifecycle.addObserver(AnimatorLifecycleObserver(animator))
 }
 
 
 fun Animator.eraseWith(lifecycleOwner: LifecycleOwner) {
-    lifecycleOwner.lifecycle.addObserver(EraserLifecycleObserver(this))
+    lifecycleOwner.lifecycle.addObserver(AnimatorLifecycleObserver(this))
 }
 
 /**
@@ -36,31 +34,5 @@ fun Animator.eraseWith(lifecycleOwner: LifecycleOwner) {
  * @param animator that must be erased
  */
 fun Fragment.erase(animator: Animator) {
-    viewLifecycleOwner.lifecycle.addObserver(EraserLifecycleObserver(animator))
-}
-
-/**
- * Observes lifecycle events and calls lifecycle methods on a provided [Animator].
- *
- * @property animator to be changes as the lifecycle being observed moves through different states
- */
-private class EraserLifecycleObserver(
-    private val animator: Animator
-) : LifecycleObserver {
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun resumeAnimator() {
-        animator.resume()
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-    fun pauseAnimator() {
-        animator.pause()
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    fun cancelAnimator() {
-        animator.cancel()
-        animator.removeAllListeners()
-    }
+    viewLifecycleOwner.lifecycle.addObserver(AnimatorLifecycleObserver(animator))
 }

--- a/eraser/src/main/java/uk/co/jordanterry/eraser/observers/AnimatorLifecycleObserver.kt
+++ b/eraser/src/main/java/uk/co/jordanterry/eraser/observers/AnimatorLifecycleObserver.kt
@@ -1,9 +1,8 @@
 package uk.co.jordanterry.eraser.observers
 
 import android.animation.Animator
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 
 /**
  * Observes lifecycle events and calls lifecycle methods on a provided [Animator].
@@ -12,21 +11,19 @@ import androidx.lifecycle.OnLifecycleEvent
  */
 internal class AnimatorLifecycleObserver(
     private val animator: Animator
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun resumeAnimator() {
+    override fun onResume(owner: LifecycleOwner) {
         animator.resume()
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-    fun pauseAnimator() {
+    override fun onPause(owner: LifecycleOwner) {
         animator.pause()
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    fun cancelAnimator() {
+    override fun onDestroy(owner: LifecycleOwner) {
         animator.cancel()
         animator.removeAllListeners()
+        owner.lifecycle.removeObserver(this)
     }
 }

--- a/eraser/src/main/java/uk/co/jordanterry/eraser/observers/AnimatorLifecycleObserver.kt
+++ b/eraser/src/main/java/uk/co/jordanterry/eraser/observers/AnimatorLifecycleObserver.kt
@@ -1,0 +1,32 @@
+package uk.co.jordanterry.eraser.observers
+
+import android.animation.Animator
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+
+/**
+ * Observes lifecycle events and calls lifecycle methods on a provided [Animator].
+ *
+ * @property animator to be changes as the lifecycle being observed moves through different states
+ */
+internal class AnimatorLifecycleObserver(
+    private val animator: Animator
+) : LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    fun resumeAnimator() {
+        animator.resume()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    fun pauseAnimator() {
+        animator.pause()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun cancelAnimator() {
+        animator.cancel()
+        animator.removeAllListeners()
+    }
+}


### PR DESCRIPTION
Moved into a new package, and renamed the old observer, alos uses the `DefaultLifecycleObserver`.

Need to workout how to write tests. 

Closes #1.