### PR TITLE
Created an `AnimatedDrawableLifecycleObserver`

### DIFF
--- a/eraser/build.gradle
+++ b/eraser/build.gradle
@@ -38,6 +38,7 @@ android {
 
 dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-common-java8:2.3.1"
     implementation "androidx.fragment:fragment-ktx:1.3.6"
     implementation "androidx.activity:activity-ktx:1.3.1"
 }

--- a/eraser/src/main/java/uk/co/jordanterry/eraser/observers/AnimatedDrawableLifecycleObserver.kt
+++ b/eraser/src/main/java/uk/co/jordanterry/eraser/observers/AnimatedDrawableLifecycleObserver.kt
@@ -1,0 +1,42 @@
+package uk.co.jordanterry.eraser.observers
+
+import android.graphics.drawable.AnimationDrawable
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+
+/**
+ * Observes lifecycle events and calls lifecycle methods on a provided [AnimationDrawable].
+ *
+ * An [AnimationDrawable] provides two "lifecycle" methods.
+ *
+ * - [AnimationDrawable.start] - this starts the drawable from it's initial frame
+ * - [AnimationDrawable.stop] - stops the animation on it's current frame and resets the animation
+ *
+ * Pausing and resuming a [AnimationDrawable] from the same place is not possible. The behaviour of
+ * this observer is as follows:
+ *
+ * - when the [Lifecycle] is paused, the [AnimationDrawable] will be stopped
+ *     - [AnimationDrawable.isOneShot] is true, the observer will remove itself
+ * - when the [Lifecycle] is resumed, the [AnimationDrawable] will be started from it's initial frame
+ *
+ * @property animationDrawable to be changed as the lifecycle being observed moves through different states
+ */
+internal class AnimatedDrawableLifecycleObserver(
+    private val animationDrawable: AnimationDrawable
+) : DefaultLifecycleObserver {
+
+    override fun onResume(owner: LifecycleOwner) {
+        if (!animationDrawable.isOneShot) {
+            animationDrawable.start()
+        }
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        animationDrawable.stop()
+        if (animationDrawable.isOneShot) {
+            owner.lifecycle.removeObserver(this)
+        }
+    }
+}
+


### PR DESCRIPTION
This PR uses the `DefaultLifecycleObserver` to implement the lifecycle events of an `AnimationDrawable` defined in #2. 

It calles `start()` on when a lifecycle passes into the `RESUMED` state and `stop` when a lifecycle passes into the `PAUSED` state. It will also unsubscribe itself when passing into the `DESTROYED` state (not neccessary, but better safe than sorry!)

Closes #2 